### PR TITLE
商品削除機能のバグ修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit, :destroy]
-  before_action :set_product, only: [:show, :edit, :update]
+  before_action :set_product, only: [:show, :edit, :update, :destroy]
   before_action :redirect_unless_owner, only: [:edit, :destroy]
 
   def index
@@ -36,8 +36,7 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    product = Product.find(params[:id])
-    product.destroy
+    @product.destroy
     redirect_to root_path
   end
 


### PR DESCRIPTION
# What
- redirect_unless_ownerの実装により、destroyアクションでエラーが発生した。
  - Renderへのデプロイ後の動作確認で発覚
- 原因は、@productの中にデータがセットされていなかったため。
- 上記エラーの解消のため、set_productの実行対象にdestroyアクションを追加。

# Why
- 商品削除機能のエラー解消のため
